### PR TITLE
Fixed download URI and DOMURIPicker to reflect Bundesbank website change

### DIFF
--- a/classes/dataBackend/file/FileDataBackend.php
+++ b/classes/dataBackend/file/FileDataBackend.php
@@ -18,7 +18,7 @@ class FileDataBackend extends DataBackend
 {
     
     // @codingStandardsIgnoreStart
-    const DOWNLOAD_URI = "https://www.bundesbank.de/Redaktion/DE/Standardartikel/Aufgaben/Unbarer_Zahlungsverkehr/bankleitzahlen_download.html";
+    const DOWNLOAD_URI = "https://www.bundesbank.de/de/aufgaben/unbarer-zahlungsverkehr/serviceangebot/bankleitzahlen/download---bankleitzahlen-602592";
     // @codingStandardsIgnoreEnd
 
     /**

--- a/classes/dataBackend/file/download/uripicker/DOMURIPicker.php
+++ b/classes/dataBackend/file/download/uripicker/DOMURIPicker.php
@@ -37,7 +37,7 @@ class DOMURIPicker implements URIPicker
         $xpath = new \DOMXpath($doc);
 
         $result = $xpath->query(
-            "//*[contains(text(),'Bankleitzahlendateien')]"
+            "//*[contains(.,'Bankleitzahlendateien')]"
         );
 
         foreach ($result as $node) {


### PR DESCRIPTION
Die Download-URL hat sich wieder geändert und die gesamte Website-Struktur.