### PR TITLE
[php7.4] Remove deprecated string offset operator.

### DIFF
--- a/classes/dataBackend/file/FileDataBackend.php
+++ b/classes/dataBackend/file/FileDataBackend.php
@@ -195,7 +195,7 @@ class FileDataBackend extends DataBackend
         $uriPicker = new FallbackURIPicker();
         $path = $uriPicker->pickURI($content);
 
-        if (strlen($path) > 0 && $path{0} != "/") {
+        if (strlen($path) > 0 && $path[0] != "/") {
             $path = sprintf("/%s/%s", dirname(self::DOWNLOAD_URI), $path);
 
         }


### PR DESCRIPTION
Use with php7.4 caused an Error: Array and string offset access syntax with curly braces is deprecated

This will make this lib useable with php7.4 .